### PR TITLE
Adding abstract template

### DIFF
--- a/abstract.md
+++ b/abstract.md
@@ -10,7 +10,6 @@ header-includes:
 
 \thispagestyle{empty}
 \noindent\begin{minipage}{\textwidth}
-\singlespacing
 \raggedleft
 {{Your Name}}
 
@@ -22,8 +21,10 @@ header-includes:
 \vspace*{\baselineskip}
 
 \centerline{\textbf{
-{{Title In Title Case}
+{{Title In Title Case}}
 }}
+
+\vspace*{\baselineskip}
 
 \centerline{\textbf{\underline{Abstract}}}
 

--- a/abstract.md
+++ b/abstract.md
@@ -1,0 +1,33 @@
+---
+header-includes:
+  - \usepackage[margin=1in, includehead]{geometry}
+  - \usepackage{fancyhdr}
+  - \pagestyle{fancy}
+  - \fancyhf{}
+  - \fancyhead[R]{-\,\thepage\,-}
+---
+
+
+\thispagestyle{empty}
+\noindent\begin{minipage}{\textwidth}
+\singlespacing
+\raggedleft
+{{Your Name}}
+
+{{Month Year}}
+
+{{Graduate Group or Dept}}
+\end{minipage}
+
+\vspace*{\baselineskip}
+
+\centerline{\textbf{
+{{Title In Title Case}
+}}
+
+\centerline{\textbf{\underline{Abstract}}}
+
+{{Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. Abstract text here. With a reference: @harris_occupancy_2011}}
+
+\vspace*{\baselineskip}
+


### PR DESCRIPTION
Wanna test this? You should run

```
pandoc -o abstract.pdf --bibliography=bib.bib --csl=citation-style.csl -V linestretch=2 -V fontsize=12pt abstract.md
```

Which is the same as the command in the README but without the `geometry` argument.  The thing is, while it builds in my dissertation directory, for some reason the blank template fails in a different directory (it has a problem with `\singlespacing` there), and I'm not sure if its an environment problem.
